### PR TITLE
WIP: Dark mode

### DIFF
--- a/_includes/layouts/base.liquid
+++ b/_includes/layouts/base.liquid
@@ -47,6 +47,7 @@
                     <li><a href="/feed.xml">RSS</a></li>
                     <li><a href="https://github.com/Stefanye/CSSHell" target="_blank" rel="noopener">GitHub</a></li>
                     <li><a href="https://twitter.com/css_hell" target="_blank" rel="noopener">Twitter</a></li>
+                    <li><img id="color-scheme-toggle" alt="light" src="/src/images/color-scheme-dark.svg"/></li>
                 </ul>
             </nav>
 
@@ -75,5 +76,6 @@
         </footer>
 
         <link rel="javascript" href="/js/prism.js">
+        <script src="/src/js/preferred-color-scheme.js"></script>
     </body>
 </html>

--- a/src/images/color-scheme-dark.svg
+++ b/src/images/color-scheme-dark.svg
@@ -1,0 +1,4 @@
+<svg id="moon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+    stroke="currentcolor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"></path>
+</svg>

--- a/src/images/color-scheme-light.svg
+++ b/src/images/color-scheme-light.svg
@@ -1,0 +1,12 @@
+<svg id="sun" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+    stroke="currentcolor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="12" cy="12" r="5"></circle>
+    <line x1="12" y1="1" x2="12" y2="3"></line>
+    <line x1="12" y1="21" x2="12" y2="23"></line>
+    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+    <line x1="1" y1="12" x2="3" y2="12"></line>
+    <line x1="21" y1="12" x2="23" y2="12"></line>
+    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+</svg>

--- a/src/js/preferred-color-scheme.js
+++ b/src/js/preferred-color-scheme.js
@@ -1,0 +1,47 @@
+(function () {
+    // based on: https://jec.fyi/blog/supporting-dark-mode
+    const bodyEl = document.body;
+    const toggleEl = document.getElementById('color-scheme-toggle');
+
+    const DARK = 'dark';
+    const LIGHT = 'light';
+    const COLOR_SCHEME_CHANGED = 'colorSchemeChanged';
+    const STORAGE_KEY = 'color-scheme';
+
+    toggleEl.addEventListener('click', () => {
+        const isDark = bodyEl.classList.toggle('dark-mode');
+        const mode = isDark ? DARK : LIGHT;
+        localStorage.setItem(STORAGE_KEY, mode);
+
+        if (isDark) {
+            toggleEl.src = toggleEl.src.replace(DARK, LIGHT);
+            toggleEl.alt = toggleEl.alt.replace(DARK, LIGHT);
+        } else {
+            toggleEl.src = toggleEl.src.replace(LIGHT, DARK);
+            toggleEl.alt = toggleEl.alt.replace(LIGHT, DARK);
+        }
+
+        toggleEl.dispatchEvent(new CustomEvent(
+            COLOR_SCHEME_CHANGED, { detail: mode }
+        ));
+    });
+
+    function init() {
+        const isSystemDarkMode = matchMedia &&
+            matchMedia('(prefers-color-scheme: dark)').matches;
+
+        let mode = localStorage.getItem(STORAGE_KEY);
+
+        if (!mode && isSystemDarkMode) {
+            mode = DARK;
+        } else {
+            mode = mode || LIGHT;
+        }
+
+        if (mode === DARK) {
+            toggleEl.click();
+        }
+    }
+
+    init();
+}())

--- a/src/sass/_home.scss
+++ b/src/sass/_home.scss
@@ -47,7 +47,7 @@
 .read-more {
     align-items: center;
     background: var(--brand-color);
-    color: #fff;
+    color: var(--link-text-color);
     display: inline-flex;
     font-weight: 500;
     padding: {
@@ -65,23 +65,23 @@
     }
     &:hover {
         background-color: var(--link-hover-color);
-        color: #fff;
+        color: var(--link-text-color);
         text-decoration: none;
     }
     &:active {
         background-color: var(--link-focus-color);
-        color: #fff;
+        color: var(--link-text-color);
         outline: 0 none;
         text-decoration: none;
     }
     &:focus {
         background-color: var(--link-focus-color);
-        color: #fff;
+        color: var(--link-text-color);
         outline: 0 none;
         text-decoration: none;
     }
     &:focus-visible {
-        color: #fff;
+        color: var(--link-text-color);
         outline: 2px solid var(--link-focus-color);
         text-decoration: none;
     }
@@ -120,16 +120,16 @@
         text-decoration: none;
         &:hover:not([aria-current="true"]) {
             background-color: var(--link-hover-color);
-            color: #fff;
+            color: var(--link-text-color);
         }
         &:active:not([aria-current="true"]) {
             background-color: var(--link-focus-color);
-            color: #fff;
+            color: var(--link-text-color);
             outline: none;
         }
         &:focus:not([aria-current="true"]) {
             background-color: var(--link-focus-color);
-            color: #fff;
+            color: var(--link-text-color);
             outline: 0 none;
         }
         &:focus-visible:not([aria-current="true"]) {
@@ -137,7 +137,7 @@
         }
         &[aria-current="true"] {
             background-color: var(--brand-color);
-            color: #fff;
+            color: var(--link-text-color);
             pointer-events: none;
         }
     }

--- a/src/sass/_layout.scss
+++ b/src/sass/_layout.scss
@@ -89,6 +89,9 @@ footer {
             fill: url('#site-header--logo-gradient');
         }
         & stop {
+            .site-header--home-link & {
+                stop-color: var(--site-header-logo-color);
+            }
             transition: .2s;
             .site-header--home-link:hover &,
             .site-header--home-link:focus & {

--- a/src/sass/_layout.scss
+++ b/src/sass/_layout.scss
@@ -102,7 +102,7 @@ footer {
         }
     }    
     &--details {
-        color: #444;
+        color: var(--heading-font-color);
         font: {
             family: var(--heading-font-family);
             size: 1.4rem;

--- a/src/sass/_post.scss
+++ b/src/sass/_post.scss
@@ -1,5 +1,5 @@
 .post-meta {
-    color: #666;
+    color: var(--post-meta-color);
     font-size: .8rem;
     margin-bottom: 1.5rem;
     & a {
@@ -51,7 +51,7 @@
 }
 
 .post-tip {
-    background-color: #f9f9f9;
+    background-color: var(--post-tip-color);
     border: .125rem dashed var(--brand-color);
     padding: 1rem;
 }

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -6,15 +6,32 @@
 @import "prism";
 
 :root {
-    --brand-color: #c41d44;
     --heading-font-family: Georgia, 'Times New Roman', Times, serif;
     --layout-max-width: 50rem;
+    
+    --brand-color: #c41d44;
     --link-hover-color: #b31a3e;
     --link-focus-color: #8b1631;
+    --link-text-color: #fff;
+    --background-color: #f1f1f1;
+    --font-color: #000;
+    --heading-font-color: #444;
+}
+
+.dark-mode {
+    --brand-color: #ff295b;
+    --link-hover-color: #fa2758;
+    --link-focus-color: #d1224b;
+    --link-text-color: #000;
+    --background-color: #333333;
+    --heading-font-color: #bbb;
+    --font-color: #fff;
 }
 
 body {
-    background-color: #f1f1f1;
+    color: var(--font-color);
+    background-color: var(--background-color);
+    transition: all 300ms ease-in-out 0s;
     font-family: "Roboto", sans-serif;
     @media screen and (max-width: 840px) {
         padding: {

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -8,7 +8,7 @@
 :root {
     --heading-font-family: Georgia, 'Times New Roman', Times, serif;
     --layout-max-width: 50rem;
-    
+    // light mode variables
     --brand-color: #c41d44;
     --link-hover-color: #b31a3e;
     --link-focus-color: #8b1631;
@@ -16,9 +16,13 @@
     --background-color: #f1f1f1;
     --font-color: #000;
     --heading-font-color: #444;
+    --site-header-logo-color: #000;
+    --post-meta-color: #666;
+    --post-tip-color: #f9f9f9;
 }
 
-.dark-mode {
+:root .dark-mode {
+    // dark mode variables
     --brand-color: #ff295b;
     --link-hover-color: #fa2758;
     --link-focus-color: #d1224b;
@@ -26,12 +30,14 @@
     --background-color: #333333;
     --heading-font-color: #bbb;
     --font-color: #fff;
+    --site-header-logo-color: #fff;
+    --post-meta-color: #888;
+    --post-tip-color: #060606;
 }
 
 body {
     color: var(--font-color);
     background-color: var(--background-color);
-    transition: all 300ms ease-in-out 0s;
     font-family: "Roboto", sans-serif;
     @media screen and (max-width: 840px) {
         padding: {


### PR DESCRIPTION
#2 

- Add basic dark mode toggle (icons are just for proof of concept)
- Start to use css variables for colors in order to easily override (proof of concept as well)

Based on:
- https://jec.fyi/blog/supporting-dark-mode
- https://web.dev/prefers-color-scheme/ 

Missing parts:
- set proper dark version of the colors
- pull up the missing colors into variables
- dark prism theme
- toggle icons that matches the design
