### PR TITLE
Merge together sass watch and serve

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -3,18 +3,16 @@ const syntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
 const filters = require('./_11ty/filters.js');
 
 module.exports = function (eleventyConfig) {
+  eleventyConfig.addWatchTarget('src/sass');
   eleventyConfig.addPassthroughCopy('src/images');
   eleventyConfig.addPassthroughCopy('src/js');
+  eleventyConfig.addPassthroughCopy({'src/css': 'css'});
 
   // Filters
   Object.keys(filters).forEach(filterName => {
     eleventyConfig.addFilter(filterName, filters[filterName])
   });
 
-  // sass config
-  eleventyConfig.setBrowserSyncConfig({
-    files: './_site/css/**/*.css'
-  });
 
   // Plugins
   eleventyConfig.addPlugin(pluginRss);

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 _site/
+/src/css/

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:sass": "node-sass src/sass -o src/css --output-style compressed",
     "watch:sass": "node-sass --watch src/sass -o src/css --output-style compressed",
     "serve": "npm-run-all build:sass --parallel watch:*",
-    "build": "npm-run-all build:*",
+    "build": "npm-run-all build:sass build:eleventy",
     "start": "netlify dev"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,12 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "eleventy",
-    "serve": "eleventy --serve",
-    "watch:sass": "node-sass --watch src/sass/main.scss _site/css/main.css --output-style compressed",
+    "build:eleventy": "eleventy",
+    "watch:eleventy": "eleventy --serve",
+    "build:sass": "node-sass src/sass -o src/css --output-style compressed",
+    "watch:sass": "node-sass --watch src/sass -o src/css --output-style compressed",
+    "serve": "npm-run-all build:sass --parallel watch:*",
+    "build": "npm-run-all build:*",
     "start": "netlify dev"
   },
   "repository": {
@@ -23,7 +26,8 @@
   "devDependencies": {
     "@11ty/eleventy": "^0.12.1",
     "@11ty/eleventy-plugin-rss": "^1.1.1",
-    "@11ty/eleventy-plugin-syntaxhighlight": "^3.1.0"
+    "@11ty/eleventy-plugin-syntaxhighlight": "^3.1.0",
+    "npm-run-all": "^4.1.5"
   },
   "dependencies": {
     "node-sass": "^5.0.0"


### PR DESCRIPTION
#15 

Based on: https://egghead.io/lessons/11ty-add-sass-compiling-and-watch-for-changes-in-eleventy-11ty

Notes:
- I think the pipeline should not directly modify files in the `_site` folder, that should handled by eleventy, thus I save the generated files to css folder, and `passthroughcopy` to the proper location
- I'm not sure what `netlify dev` does, I hope these changes did not break the workflow
- new dependency: [npm-run-all](https://www.npmjs.com/package/npm-run-all), cross platform, seems legit by their user count
- I do not trust the globstar in the tutorial's `build:*`, we have to run sass first thus `"build": "npm-run-all build:sass build:eleventy",` seems more reliable